### PR TITLE
[jenkins] add support for reporting build parameters as event tags

### DIFF
--- a/checks.d/jenkins.py
+++ b/checks.d/jenkins.py
@@ -89,6 +89,17 @@ class Jenkins(AgentCheck):
                     .text
             except Exception:
                 pass
+
+            try:
+                d['parameters'] = {
+                    e.find('name').text: e.find('value').text for e in
+                    tree.find('actions')
+                        .find('hudson.model.ParametersAction')
+                        .find('parameters')
+                }
+            except Exception:
+                d['parameters'] = {}
+
             return d
 
     def _get_build_results(self, instance_key, job_dir):
@@ -148,6 +159,7 @@ class Jenkins(AgentCheck):
             self.check(instance, create_event=False)
 
         jenkins_home = instance.get('jenkins_home')
+        parameters = instance.get('parameters', {})
 
         if not jenkins_home:
             raise Exception("No jenkins_home directory set in the config file")
@@ -175,6 +187,12 @@ class Jenkins(AgentCheck):
                     if 'branch' in output:
                         tags.append('branch:%s' % output['branch'])
                     self.gauge("jenkins.job.duration", float(output['duration'])/1000.0, tags=tags)
+
+                    tags.extend([
+                        '%s:%s' % (tag, output['parameters'][parameter])
+                        for parameter, tag in parameters.iteritems()
+                        if parameter in output['parameters']
+                    ])
 
                     if output['result'] == 'SUCCESS':
                         self.increment('jenkins.job.success', tags=tags)

--- a/tests/checks/mock/test_jenkins.py
+++ b/tests/checks/mock/test_jenkins.py
@@ -7,9 +7,6 @@ import shutil
 import tempfile
 import unittest
 
-# 3p
-import xml.etree.ElementTree as ET
-
 # project
 from tests.checks.common import get_check
 
@@ -18,9 +15,42 @@ logger = logging.getLogger(__file__)
 DATETIME_FORMAT = '%Y-%m-%d_%H-%M-%S'
 LOG_DATA = 'Finished: SUCCESS'
 
-SUCCESSFUL_BUILD = {'number': '99', 'result': 'SUCCESS', 'duration': '60'}
-NO_RESULTS_YET = {'number': '99', 'duration': '60'}
-UNSUCCESSFUL_BUILD = {'number': '99', 'result': 'ABORTED', 'duration': '60'}
+SUCCESSFUL_BUILD = """
+<build>
+    <number>99</number>
+    <result>SUCCESS</result>
+    <duration>60</duration>
+    <actions>
+        <hudson.model.ParametersAction>
+            <parameters>
+                <hudson.model.StringParameterValue>
+                    <name>GIT_BRANCH</name>
+                    <value>master</value>
+                </hudson.model.StringParameterValue>
+                <hudson.model.StringParameterValue>
+                    <name>GIT_COMMIT</name>
+                    <value>6eb60abff25135a2c4fe088a02e5ed2161bfcd95</value>
+                </hudson.model.StringParameterValue>
+            </parameters>
+        </hudson.model.ParametersAction>
+    </actions>
+</build>
+"""
+
+NO_RESULTS_YET = """
+<build>
+    <number>99</build>
+    <duration>60</duration>
+</build>
+"""
+
+UNSUCCESSFUL_BUILD = """
+<build>
+    <number>99</number>
+    <result>ABORTED</result>
+    <duration>60</duration>
+</build>
+"""
 
 CONFIG = """
 init_config:
@@ -28,18 +58,10 @@ init_config:
 instances:
     -   name: default
         jenkins_home: <JENKINS_HOME>
+        parameters:
+            GIT_BRANCH: branch
+            EXTRA_PARAM: extra_param
 """
-
-
-def dict_to_xml(metadata_dict):
-    """ Convert a dict to xml for use in a build.xml file """
-    build = ET.Element('build')
-    for k, v in metadata_dict.iteritems():
-        node = ET.SubElement(build, k)
-        node.text = v
-
-    return ET.tostring(build)
-
 
 def write_file(file_name, log_data):
     with open(file_name, 'w') as log_file:
@@ -61,9 +83,8 @@ class TestJenkins(unittest.TestCase):
         # As coded, the jenkins dd agent needs more than one result
         # in order to get the last valid build.
         # Create one for yesterday.
-        metadata = dict_to_xml(SUCCESSFUL_BUILD)
         yesterday = datetime.date.today() - datetime.timedelta(days=1)
-        self._populate_build_dir(metadata, yesterday)
+        self._populate_build_dir(SUCCESSFUL_BUILD, yesterday)
 
     def _create_check(self):
         # Create the jenkins check
@@ -90,9 +111,7 @@ class TestJenkins(unittest.TestCase):
         Test doing a jenkins check. This will parse the logs but since there was no
         previous high watermark no event will be created.
         """
-        metadata = dict_to_xml(SUCCESSFUL_BUILD)
-
-        self._populate_build_dir(metadata)
+        self._populate_build_dir(SUCCESSFUL_BUILD)
         self._create_check()
         self.check.check(self.instance)
 
@@ -104,9 +123,7 @@ class TestJenkins(unittest.TestCase):
         """
         Test that a successful build will create the correct metrics.
         """
-        metadata = dict_to_xml(SUCCESSFUL_BUILD)
-
-        self._populate_build_dir(metadata)
+        self._populate_build_dir(SUCCESSFUL_BUILD)
         self._create_check()
 
         # Set the high_water mark so that the next check will create events
@@ -126,14 +143,13 @@ class TestJenkins(unittest.TestCase):
             assert 'job_name:foo' in tag.get('tags')
             assert 'result:SUCCESS' in tag.get('tags')
             assert 'build_number:99' in tag.get('tags')
+            assert 'branch:master' in tag.get('tags')
 
     def testCheckUnsuccessfulEvent(self):
         """
         Test that an unsuccessful build will create the correct metrics.
         """
-        metadata = dict_to_xml(UNSUCCESSFUL_BUILD)
-
-        self._populate_build_dir(metadata)
+        self._populate_build_dir(UNSUCCESSFUL_BUILD)
         self._create_check()
 
         # Set the high_water mark so that the next check will create events
@@ -159,9 +175,7 @@ class TestJenkins(unittest.TestCase):
         Test under the conditions of a jenkins build still running.
         The build.xml file will exist but it will not yet have a result.
         """
-        metadata = dict_to_xml(NO_RESULTS_YET)
-
-        self._populate_build_dir(metadata)
+        self._populate_build_dir(NO_RESULTS_YET)
         self._create_check()
 
         # Set the high_water mark so that the next check will create events


### PR DESCRIPTION
Jenkins checks can now be configured to report arbitrary build parameters as
event tags. For example, consider a config that looks like

```
init_config:

instances:
  - name: default
    jenkins_home: /var/lib/jenkins
    parameters:
      GIT_BRANCH: branch
```

and a Jenkins job where the `GIT_BRANCH` parameter is set to `master`. With
this patch the resulting DataDog event will have a `branch:master` tag
associated with it.

(This particular example illustrates why Stripe authored this patch: we don't
use the Jenkins Git plugin but still want branch information to be threaded
through to DataDog.)

While expanding `test_jenkins.py` to cover this new functionality, I replaced
the dict-to-XML helper with handwritten XML strings because it seemed simpler
than enhancing the helper to generate the more complex XML needed for the new
test coverage.